### PR TITLE
Use IOID 12/15 for UART0

### DIFF
--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/CC1312R1_LAUNCHXL.c
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/CC1312R1_LAUNCHXL.c
@@ -760,8 +760,10 @@ const PIN_Config BoardGpioInitTable[] = {
     CC1312R1_LAUNCHXL_PIN_BTN1 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low       */
     CC1312R1_LAUNCHXL_PIN_BTN2 | PIN_INPUT_EN | PIN_PULLUP | PIN_IRQ_BOTHEDGES | PIN_HYSTERESIS,          /* Button is active low       */
     CC1312R1_LAUNCHXL_SPI_FLASH_CS | PIN_GPIO_OUTPUT_EN | PIN_GPIO_HIGH | PIN_PUSHPULL | PIN_DRVSTR_MIN,  /* External flash chip select */
-    CC1312R1_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                              /* UART RX via debugger back channel */
+    CC1312R1_LAUNCHXL_UART_RX | PIN_INPUT_EN | PIN_PULLDOWN,                                                /* UART RX via debugger back channel */
     CC1312R1_LAUNCHXL_UART_TX | PIN_GPIO_OUTPUT_EN | PIN_GPIO_LOW | PIN_PUSHPULL,                         /* UART TX via debugger back channel */
+    CC1312R1_LAUNCHXL_UART1_RX  | PIN_INPUT_EN | PIN_PULLUP,                                              /* IOID_12 UART1 RX -181101(I)- */
+    CC1312R1_LAUNCHXL_UART1_TX  | PIN_GPIO_OUTPUT_EN | PIN_GPIO_LOW  | PIN_PUSHPULL,                      /* IOID_15 UART1 TX -181101(I)- */
     CC1312R1_LAUNCHXL_SPI0_MOSI | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master out - slave in */
     CC1312R1_LAUNCHXL_SPI0_MISO | PIN_INPUT_EN | PIN_PULLDOWN,                                            /* SPI master in - slave out */
     CC1312R1_LAUNCHXL_SPI0_CLK | PIN_INPUT_EN | PIN_PULLDOWN,                                             /* SPI clock */

--- a/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/CC1312R1_LAUNCHXL.h
+++ b/arch/platform/simplelink/cc13xx-cc26xx/launchpad/cc1312r1/CC1312R1_LAUNCHXL.h
@@ -137,12 +137,12 @@ extern const PIN_Config BoardGpioInitTable[];
 #define CC1312R1_LAUNCHXL_SPI1_CSN              PIN_UNASSIGNED
 
 /* UART Board */
-#define CC1312R1_LAUNCHXL_UART0_RX              IOID_2          /* RXD */
-#define CC1312R1_LAUNCHXL_UART0_TX              IOID_3          /* TXD */
-#define CC1312R1_LAUNCHXL_UART0_CTS             IOID_19         /* CTS */
-#define CC1312R1_LAUNCHXL_UART0_RTS             IOID_18         /* RTS */
-#define CC1312R1_LAUNCHXL_UART1_RX              PIN_UNASSIGNED
-#define CC1312R1_LAUNCHXL_UART1_TX              PIN_UNASSIGNED
+#define CC1312R1_LAUNCHXL_UART0_RX              CC1312R1_LAUNCHXL_DIO12  /* RXD */
+#define CC1312R1_LAUNCHXL_UART0_TX              CC1312R1_LAUNCHXL_DIO15  /* TXD */
+#define CC1312R1_LAUNCHXL_UART0_CTS             IOID_19                  /* CTS */
+#define CC1312R1_LAUNCHXL_UART0_RTS             IOID_18                  /* RTS */
+#define CC1312R1_LAUNCHXL_UART1_RX              IOID_2                   /* RXD */
+#define CC1312R1_LAUNCHXL_UART1_TX              IOID_3                   /* TXD */
 #define CC1312R1_LAUNCHXL_UART1_CTS             PIN_UNASSIGNED
 #define CC1312R1_LAUNCHXL_UART1_RTS             PIN_UNASSIGNED
 /* For backward compatibility */


### PR DESCRIPTION
- UART1 now uses IOID 2/3 pins